### PR TITLE
ignore Specified key was too long error message

### DIFF
--- a/ddl/run.go
+++ b/ddl/run.go
@@ -181,7 +181,8 @@ func ddlIgnoreError(err error) bool {
 		strings.Contains(errStr, "cannot convert") ||
 		strings.Contains(errStr, "Data Too Long") ||
 		// eg: For v"BLOB/TEXT column '319de167-6d2e-4778-966c-60b95103a02c' used in key specification without a key length"
-		strings.Contains(errStr, "used in key specification without a key length") {
+		strings.Contains(errStr, "used in key specification without a key length") ||
+		strings.Contains(errStr, "Specified key was too long; max key length is ") {
 		fmt.Println(errStr)
 		return true
 	}


### PR DESCRIPTION
```
 2022/02/23 01:30:34 run.go:152: [warning] check DDL err:Error 1071: Specified key was too long; max key length is 3072 bytes
2022/02/23 01:30:34 util.go:78: [error] error: Error when executing SQL: ALTER TABLE `68781875-02b9-4631-943d-f7631639af3b` ADD INDEX `e540d320-624a-4c9d-a46b-e9fd5ace0d8b` (`ea9d3ec4-9732-4beb-915e-30192227842c`, `2b271755-4b4f-45ef-bd44-1d84984ae42f`, `d4055f97-4158-4429-a6e4-22b559a4aac2`, `3204ecf7-e046-4998-b2d3-929a80e041d3`, `a2fa1717-7803-42ce-8682-03c95654eb66`, `26798797-5369-40ab-b799-37e3a04c5d99`, `d38c6084-da22-43a9-95ed-5c8b5755b337`, `1431c6f7-81d7-4ff4-afda-3e18f7732723`, `00defb6c-5e3f-48ef-81d7-73e0b1678c3f`, `9a6dfcb7-baed-45fc-9ca9-99c80086a119`)
 remote tidb Err: &mysql.MySQLError{Number:0x42f, Message:"Specified key was too long; max key length is 3072 bytes"} 
```

https://prow.hawkingrei.com/view/gs/prowpingcap/logs/ddl_test_master/1496269991643713536

Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>