### PR TITLE
ddl_ops: fix default value for timestamp

### DIFF
--- a/ddl/ddl_ops.go
+++ b/ddl/ddl_ops.go
@@ -368,7 +368,6 @@ func (c *testCase) checkTableColumns(table *ddlTestTable) error {
 				log.Errorf("error %s, stack %s", err.Error(), debug.Stack())
 				return err
 			}
-			t = t.UTC()
 			expectedDefault = t.Format(TimeFormat)
 		}
 		if !column.canHaveDefaultValue() {


### PR DESCRIPTION
after https://github.com/pingcap/tidb/pull/36851, the result of default value has changed, so need fix it.