### PR TITLE
ignore unsupported multi schema change error

### DIFF
--- a/ddl/run.go
+++ b/ddl/run.go
@@ -141,6 +141,9 @@ func dmlIgnoreError(err error) bool {
 		strings.Contains(errStr, "cannot convert datum from decimal to type year") {
 		return true
 	}
+	if strings.Contains(errStr, "Unsupported multi schema change") {
+		return true
+	}
 	return false
 }
 


### PR DESCRIPTION
Prior to TiDB v6.2.0, multi-schema change is not supported. We need to ignore these errors.