### PR TITLE
make the build action on x64 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
     branches: [ master ]
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: [self-hosted, Linux, X64]
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
There are 2 runners for this repo (https://github.com/PingCAP-QE/schrddl/settings/actions/runners),  the default test-infra resource pool is x86, so let the build always using x64 runner.