### PR TITLE
Revert "ddl_ops: fix timezone"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build
 on:
   push:
-    branches: [ master ]
+    branches: [ release-6.1 ]
 jobs:
   build:
     runs-on: [self-hosted, Linux, X64]

--- a/ddl/ddl_ops.go
+++ b/ddl/ddl_ops.go
@@ -381,6 +381,7 @@ func (c *testCase) checkTableColumns(table *ddlTestTable) error {
 				log.Errorf("error %s, stack %s", err.Error(), debug.Stack())
 				return err
 			}
+			t = t.UTC()
 			expectedDefault = t.Format(TimeFormat)
 		}
 		if !column.canHaveDefaultValue() {


### PR DESCRIPTION
This reverts commit fc6f0d96f87fabb4b3fd6c514dc01decf27a42b4. It incompatible with release-6.1.x, so revert it.