### PR TITLE
ddl: Let schrddl support run on TiDB release-6.1.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build
 on:
   push:
-    branches: [ master ]
+    branches: [ release-6.1 ]
 jobs:
   build:
     runs-on: [self-hosted, Linux, X64]

--- a/ddl/ddl_ops.go
+++ b/ddl/ddl_ops.go
@@ -381,6 +381,7 @@ func (c *testCase) checkTableColumns(table *ddlTestTable) error {
 				log.Errorf("error %s, stack %s", err.Error(), debug.Stack())
 				return err
 			}
+			t = t.UTC()
 			expectedDefault = t.Format(TimeFormat)
 		}
 		if !column.canHaveDefaultValue() {

--- a/ddl/run.go
+++ b/ddl/run.go
@@ -141,9 +141,6 @@ func dmlIgnoreError(err error) bool {
 		strings.Contains(errStr, "cannot convert datum from decimal to type year") {
 		return true
 	}
-	if strings.Contains(errStr, "Unsupported multi schema change") {
-		return true
-	}
 	return false
 }
 
@@ -209,7 +206,8 @@ func ddlIgnoreError(err error) bool {
 		strings.Contains(errStr, "Out of range value for column") || strings.Contains(errStr, "Unknown column") ||
 		strings.Contains(errStr, "column has index reference") || strings.Contains(errStr, "Data too long for column") ||
 		strings.Contains(errStr, "Data truncated") || strings.Contains(errStr, "no rows in result set") ||
-		strings.Contains(errStr, "with tidb_enable_change_multi_schema is disable") {
+		strings.Contains(errStr, "with tidb_enable_change_multi_schema is disable") ||
+		strings.Contains(errStr, "Unsupported multi schema change") {
 		return true
 	}
 	return false


### PR DESCRIPTION
This reverts commit fc6f0d9. It incompatible with release-6.1.x, so revert it.