### PR TITLE
add branch for build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Build
-      run: docker build -t hub.pingcap.net/qa/schrddl .
+      run: docker build -t hub.pingcap.net/qa/schrddl-master .
     - name: Docker Login
       uses: docker/login-action@v1
       with:
@@ -17,4 +17,4 @@ jobs:
         username: ${{ secrets.HARBOR_USERNAME }}
         password: ${{ secrets.HARBOR_PASSWORD }}
     - name: Push
-      run: docker push hub.pingcap.net/qa/schrddl
+      run: docker push hub.pingcap.net/qa/schrddl-master


### PR DESCRIPTION
#36 add the release-6.1 image build but not change image tag, `hub.pingcap.net/qa/schrddl` docker images  use the release-6.1 case cover the master case.
add the master tag for master case image, need to change the default image for https://tcms.pingcap.net/dashboard/cases/480338 