### PR TITLE
fix error filter for release-6.1

### DIFF
--- a/ddl/run.go
+++ b/ddl/run.go
@@ -185,7 +185,7 @@ func ddlIgnoreError(err error) bool {
 		strings.Contains(errStr, "used in key specification without a key length") ||
 		strings.Contains(errStr, "Specified key was too long; max key length is ") ||
 		strings.Contains(errStr, "should be less than the total tiflash server count") ||
-		strings.Contains(errStr, "Unsupported ALTER TiFlash settings") {
+		strings.Contains(errStr, "Unsupported ALTER table replica for table contain gbk charset") {
 		fmt.Println(errStr)
 		return true
 	}


### PR DESCRIPTION
```sql
TiDB root@127.0.0.1:test> create table t1(a varchar(20) charset gbk collate gbk_chinese_ci);
Reconnecting...
Query OK, 0 rows affected
Time: 0.119s
TiDB root@127.0.0.1:test> alter table t1 set tiflash replica 1;
(8200, 'Unsupported ALTER table replica for table contain gbk charset')
TiDB root@127.0.0.1:test> select tidb_version()\G
***************************[ 1. row ]***************************
tidb_version() | Release Version: v6.1.1
Edition: Community
Git Commit Hash: 5263a0abda61f102122735049fd0dfadc7b7f8b2
Git Branch: heads/refs/tags/v6.1.1
UTC Build Time: 2022-08-25 10:35:49
GoVersion: go1.18.5
Race Enabled: false
TiKV Min Version: v3.0.0-60965b006877ca7234adaced7890d7b029ed1306
Check Table Before Drop: false
```

tiflash unsupported gbk  error info in release-6.1 is different from master.