### PR TITLE
fix: use AggFuncDesc to get column type of AggregateFuncExpr

### DIFF
--- a/framework/mainloop.go
+++ b/framework/mainloop.go
@@ -594,6 +594,7 @@ func (c *testCase) execute(ctx context.Context) error {
 	}
 	log.Infof("tableMetas %d", len(tableMetas))
 	state.SetTableMeta(tableMetas)
+	state.PrepareIndexJoinColumns()
 
 	cnt := 0
 

--- a/framework/meta.go
+++ b/framework/meta.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"github.com/pingcap/tidb/pkg/parser"
 	"math/rand"
 	"os"
 	"sort"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/PingCAP-QE/schrddl/sqlgenerator"
 	"github.com/emirpasic/gods/lists/arraylist"
+	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/twinj/uuid"
 )
 
@@ -40,15 +40,16 @@ type testCase struct {
 	tidbParser *parser.Parser
 
 	// stat info
-	queryPlanMap     map[string]string
-	originalSQL      string
-	reduceChangedSQL string
-	reduceSQL        string
-	planUseMvIndex   int
-	cntOfOldOriginal int
-	cntOfNewOriginal int
-	cntOfOldReduce   int
-	cntOfNewReduce   int
+	queryPlanMap                      map[string]string
+	originalSQL                       string
+	reduceChangedSQL                  string
+	reduceSQL                         string
+	aggregationAsInnerSideOfIndexJoin int
+	planUseMvIndex                    int
+	cntOfOldOriginal                  int
+	cntOfNewOriginal                  int
+	cntOfOldReduce                    int
+	cntOfNewReduce                    int
 
 	// cert
 	oldEstCntOriginal float64

--- a/framework/run.go
+++ b/framework/run.go
@@ -99,6 +99,8 @@ func Run(dbAddr string, dbName string, concurrency int, tablesToCreate int, mysq
 	if err := ddl.Execute(ctx, dbss); err != nil {
 		log.Fatalf("[ddl] execute error %v", err)
 	}
+	// Enable index join on aggregation
+	globalDbs.Exec("set GLOBAL tidb_enable_inl_join_inner_multi_pattern='ON'")
 }
 
 var dmlIgnoreList = []string{

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func prepareEnv() {
 	}
 	if _, err = tidbC.ExecContext(context.Background(), fmt.Sprintf("set global time_zone='%s'", Local.String())); err != nil {
 		if _, err = tidbC.ExecContext(context.Background(), fmt.Sprintf("set global time_zone='%s'", time.Local.String())); err != nil {
-			if _, err = tidbC.ExecContext(context.Background(), fmt.Sprintf("set global time_zone='+8:00'")); err != nil {
+			if _, err = tidbC.ExecContext(context.Background(), "set global time_zone='+8:00'"); err != nil {
 				log.Fatalf("Can't set time_zone for tidb, please check tidb env")
 			}
 		}

--- a/sqlgenerator/db_constant.go
+++ b/sqlgenerator/db_constant.go
@@ -366,4 +366,5 @@ const (
 
 const (
 	QueryAggregation = "agg"
+	ChosenSelection  = "Selection"
 )

--- a/sqlgenerator/db_type.go
+++ b/sqlgenerator/db_type.go
@@ -1,9 +1,53 @@
 package sqlgenerator
 
 import (
-	"github.com/pingcap/tidb/pkg/parser/model"
 	"math/rand"
+
+	"github.com/pingcap/tidb/pkg/parser/model"
 )
+
+var indexJoinType = map[ColumnType][]ColumnType{
+	ColumnTypeBoolean: {
+		ColumnTypeBoolean, ColumnTypeTinyInt, ColumnTypeSmallInt, ColumnTypeMediumInt, ColumnTypeInt,
+		ColumnTypeBigInt, ColumnTypeDouble, ColumnTypeDecimal, ColumnTypeYear, ColumnTypeBit},
+	ColumnTypeTinyInt: {
+		ColumnTypeBoolean, ColumnTypeTinyInt, ColumnTypeSmallInt, ColumnTypeMediumInt, ColumnTypeInt,
+		ColumnTypeBigInt, ColumnTypeDouble, ColumnTypeDecimal, ColumnTypeYear, ColumnTypeBit},
+	ColumnTypeSmallInt: {
+		ColumnTypeBoolean, ColumnTypeTinyInt, ColumnTypeSmallInt, ColumnTypeMediumInt, ColumnTypeInt,
+		ColumnTypeBigInt, ColumnTypeFloat, ColumnTypeDouble, ColumnTypeDecimal, ColumnTypeYear, ColumnTypeBit},
+	ColumnTypeMediumInt: {
+		ColumnTypeBoolean, ColumnTypeTinyInt, ColumnTypeSmallInt, ColumnTypeMediumInt, ColumnTypeInt,
+		ColumnTypeBigInt, ColumnTypeFloat, ColumnTypeDouble, ColumnTypeDecimal, ColumnTypeYear, ColumnTypeBit},
+	ColumnTypeInt: {
+		ColumnTypeBoolean, ColumnTypeTinyInt, ColumnTypeSmallInt, ColumnTypeMediumInt, ColumnTypeInt,
+		ColumnTypeBigInt, ColumnTypeFloat, ColumnTypeDouble, ColumnTypeDecimal, ColumnTypeYear, ColumnTypeBit},
+	ColumnTypeBigInt: {
+		ColumnTypeBoolean, ColumnTypeTinyInt, ColumnTypeSmallInt, ColumnTypeMediumInt, ColumnTypeInt,
+		ColumnTypeBigInt, ColumnTypeFloat, ColumnTypeDouble, ColumnTypeDecimal, ColumnTypeYear, ColumnTypeBit},
+	ColumnTypeFloat:   {ColumnTypeFloat, ColumnTypeDouble},
+	ColumnTypeDouble:  {ColumnTypeFloat, ColumnTypeDouble},
+	ColumnTypeDecimal: {ColumnTypeFloat, ColumnTypeDouble, ColumnTypeDecimal},
+	ColumnTypeChar: {
+		ColumnTypeFloat, ColumnTypeDouble, ColumnTypeChar, ColumnTypeVarchar,
+		ColumnTypeDate, ColumnTypeDatetime, ColumnTypeTimestamp},
+	ColumnTypeVarchar: {
+		ColumnTypeFloat, ColumnTypeDouble, ColumnTypeChar, ColumnTypeVarchar,
+		ColumnTypeDate, ColumnTypeDatetime, ColumnTypeTimestamp},
+	ColumnTypeDate: {ColumnTypeFloat, ColumnTypeDouble, ColumnTypeDate, ColumnTypeDatetime, ColumnTypeTimestamp},
+	ColumnTypeTime: {
+		ColumnTypeFloat, ColumnTypeDouble, ColumnTypeChar, ColumnTypeVarchar,
+		ColumnTypeDate, ColumnTypeTime, ColumnTypeDatetime, ColumnTypeTimestamp},
+	ColumnTypeDatetime:  {ColumnTypeFloat, ColumnTypeDouble, ColumnTypeDate, ColumnTypeDatetime, ColumnTypeTimestamp},
+	ColumnTypeTimestamp: {ColumnTypeFloat, ColumnTypeDouble, ColumnTypeDate, ColumnTypeDatetime, ColumnTypeTimestamp},
+	ColumnTypeYear: {
+		ColumnTypeBoolean, ColumnTypeTinyInt, ColumnTypeSmallInt, ColumnTypeMediumInt, ColumnTypeInt,
+		ColumnTypeBigInt, ColumnTypeFloat, ColumnTypeDouble, ColumnTypeDecimal, ColumnTypeDate,
+		ColumnTypeDatetime, ColumnTypeTimestamp, ColumnTypeYear, ColumnTypeBit},
+	ColumnTypeBit: {
+		ColumnTypeBoolean, ColumnTypeTinyInt, ColumnTypeSmallInt, ColumnTypeMediumInt, ColumnTypeInt,
+		ColumnTypeBigInt, ColumnTypeFloat, ColumnTypeDouble, ColumnTypeDecimal, ColumnTypeYear, ColumnTypeBit},
+}
 
 type State struct {
 	hooks  *Hooks
@@ -13,6 +57,7 @@ type State struct {
 
 	Tables        Tables
 	droppedTables Tables
+	joinColumns   []*JoinColumn
 
 	ctes     [][]*Table
 	subQuery [][]*Table
@@ -25,6 +70,13 @@ type State struct {
 	tableMeta []*model.TableInfo
 
 	fnStack string
+}
+
+type JoinColumn struct {
+	outerTable   *Table
+	innerTable   *Table
+	outerColumns []*Column
+	innerColumns []*Column
 }
 
 type Table struct {
@@ -50,6 +102,7 @@ type Table struct {
 
 type Column struct {
 	ID        int
+	Idx       int
 	Name      string
 	Tp        ColumnType
 	Collation *Collation
@@ -252,4 +305,67 @@ func (m *MultiObjs) AddName(name string) {
 
 func (s *State) SetTableMeta(tableMeta []*model.TableInfo) {
 	s.tableMeta = tableMeta
+}
+
+func (s *State) PrepareIndexJoinColumns() {
+	var CheckFunc = func(left, right ColumnType) bool {
+		if matches, ok := indexJoinType[left]; ok {
+			for _, match := range matches {
+				if right == match {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	// Enumerate possible join columns
+	for i := 0; i < len(s.Tables); i++ {
+		for j := 0; j < len(s.Tables); j++ {
+			outerTable := s.Tables[i]
+			innerTable := s.Tables[j]
+
+			var comb = JoinColumn{
+				outerTable:   outerTable,
+				innerTable:   innerTable,
+				outerColumns: make([]*Column, 0),
+				innerColumns: make([]*Column, 0),
+			}
+
+			for _, outerCol := range outerTable.Columns {
+				for _, innerIndex := range innerTable.Indexes {
+					if CheckFunc(outerCol.Tp, innerIndex.Columns[0].Tp) {
+						comb.outerColumns = append(comb.outerColumns, outerCol)
+						comb.innerColumns = append(comb.innerColumns, innerIndex.Columns[0])
+					}
+				}
+			}
+
+			if len(comb.innerColumns) > 0 {
+				s.joinColumns = append(s.joinColumns, &comb)
+			}
+		}
+	}
+}
+
+func (s *State) RandJoinColumn() (*Table, *Table, *Column, *Column) {
+	totalNum := 0
+	for _, joinColumn := range s.joinColumns {
+		totalNum += len(joinColumn.innerColumns)
+	}
+
+	if totalNum == 0 {
+		return nil, nil, nil, nil
+	}
+
+	idx := rand.Intn(totalNum)
+	for _, joinColumn := range s.joinColumns {
+		if idx < len(joinColumn.innerColumns) {
+			return joinColumn.outerTable, joinColumn.innerTable,
+				joinColumn.outerColumns[idx], joinColumn.innerColumns[idx]
+		}
+		idx -= len(joinColumn.innerColumns)
+	}
+
+	return nil, nil, nil, nil
 }

--- a/sqlgenerator/rule_column.go
+++ b/sqlgenerator/rule_column.go
@@ -14,7 +14,7 @@ var ColumnDefinitions = NewFn(func(state *State) Fn {
 
 var ColumnDefinition = NewFn(func(state *State) Fn {
 	tbl := state.env.Table
-	partialCol := &Column{ID: state.alloc.AllocColumnID()}
+	partialCol := &Column{ID: state.alloc.AllocColumnID(), Idx: len(tbl.Columns)}
 	state.env.Column = partialCol
 	// Example:
 	//   a varchar(255) collate utf8mb4_bin not null

--- a/sqlgenerator/rule_query.go
+++ b/sqlgenerator/rule_query.go
@@ -18,10 +18,11 @@ var QueryOrCTE = NewFn(func(state *State) Fn {
 
 var Query = NewFn(func(state *State) Fn {
 	return Or(
-		SingleSelect,
-		MultiSelect,
-		UnionSelect,
-		MultiSelectWithSubQuery,
+		SingleSelect.W(4),
+		MultiSelect.W(4),
+		UnionSelect.W(4),
+		MultiSelectWithSubQuery.W(4),
+		MultiSelectWithIndexJoin.W(1),
 	)
 }).P(HasTables)
 
@@ -114,6 +115,75 @@ var CTESelect = NewFn(func(state *State) Fn {
 	return And(WithClause, PostHandleWith, CommonSelect)
 })
 
+var MultiSelectWithIndexJoin = NewFn(func(state *State) Fn {
+	tbl1, tbl2, col1, col2 := state.RandJoinColumn()
+	if tbl1 == nil {
+		return NoneBecauseOf(fmt.Errorf("not initialized"))
+	}
+
+	// Generate subquery
+	state.IncSubQueryDeep()
+	st := state.GenSubQuery()
+	state.env.QState = &QueryState{
+		SelectedCols: map[*Table]QueryStateColumns{
+			tbl2: {
+				Columns: tbl2.Columns,
+				Attr:    make([]string, len(tbl2.Columns)),
+			},
+		},
+		AggCols: make(map[*Table]Columns),
+	}
+	state.env.QState.SelectedCols[tbl2].Attr[col2.Idx] = ChosenSelection
+
+	def, err := SimpleAggSelect.Eval(state)
+	if err != nil {
+		return NoneBecauseOf(err)
+	}
+	var cts []ColumnType
+	cts, err = getTypeOfExpressions(def, "test", state.tableMeta)
+	if err != nil {
+		return NoneBecauseOf(err)
+	}
+	for _, t := range cts {
+		st.AppendColumn(state.GenNewColumnWithType(t))
+	}
+	// Reset column name
+	for i, c := range st.Columns {
+		c.Name = fmt.Sprintf("r%d", i)
+	}
+	state.PushSubQuery(st)
+
+	tbl2Str := fmt.Sprintf("(%s) %s", def, st.Name)
+	sq := state.PopSubQuery()
+	sq[0].SubQueryDef = tbl2Str
+	state.env.QState = &QueryState{
+		SelectedCols: map[*Table]QueryStateColumns{
+			tbl1: {
+				Columns: tbl1.Columns,
+				Attr:    make([]string, len(tbl1.Columns)),
+			},
+			sq[0]: {
+				Columns: sq[0].Columns,
+				Attr:    make([]string, len(sq[0].Columns)),
+			},
+		},
+		AggCols: make(map[*Table]Columns),
+	}
+
+	joinHint := Str(fmt.Sprintf("/*+ inl_join(%s) */", sq[0].Name))
+	joinPredicate := Str(
+		fmt.Sprintf("on %s.%s = %s.%s",
+			tbl1.Name, col1.Name, st.Name, sq[0].Columns[0].Name))
+
+	tblNames := []Fn{Str(tbl1.Name), Str(tbl2Str)}
+	join := Join(tblNames, Or(Str("left join"), Str("inner join")))
+
+	return And(
+		Str("select"), joinHint, SelectFields,
+		Str("from"), join, joinPredicate, Opt(OrderBy), Opt(Limit),
+	)
+})
+
 var MultiSelectWithSubQuery = NewFn(func(state *State) Fn {
 	tbl1 := state.Tables.Rand()
 	tbl2Str, err := TableSubQuery.Eval(state)
@@ -183,6 +253,25 @@ var GroupByColumns = NewFn(func(state *State) Fn {
 	return Strs("group by", strings.Join(groupByItems, ","))
 })
 
+var SimpleAggSelect = NewFn(func(state *State) Fn {
+	state.env.QState.IsAgg = true
+	tbl := state.env.QState.GetRandTable()
+
+	groupByColsCnt := rand.Intn(3)
+	groupByCols := tbl.Columns.RandGiveN(groupByColsCnt)
+	for i, attr := range state.env.QState.SelectedCols[tbl].Attr {
+		if attr == ChosenSelection {
+			groupByCols = append([]*Column{tbl.Columns[i]}, groupByCols...)
+		}
+	}
+	state.env.QState.AggCols[tbl] = groupByCols
+
+	return And(
+		Str("select"), Opt(HintAggToCop), SimpleSelectFields, Str("from"),
+		TableReference, WhereClause, GroupByColumns,
+	)
+})
+
 var AggSelect = NewFn(func(state *State) Fn {
 	state.env.QState.IsAgg = true
 	// Choose aggregate columns.
@@ -211,6 +300,38 @@ var CommonSelect = NewFn(func(state *State) Fn {
 		NonAggSelect,
 		AggSelect,
 	)
+})
+
+var SimpleSelectFields = NewFn(func(state *State) Fn {
+	queryState := state.env.QState
+	queryState.FieldNumHint = 2 + rand.Intn(4)
+
+	tbl := queryState.GetRandTable()
+
+	var fns []Fn
+
+	// We need at least one column for join and one aggregation function
+	fns = append(fns, NewFn(func(state *State) Fn {
+		state.env.Table = tbl
+		return Str(fmt.Sprintf("%s.%s as r0", tbl.Name, state.env.QState.AggCols[tbl][0].Name))
+	}))
+	fns = append(fns, Str(","))
+	fns = append(fns, NewFn(func(state *State) Fn {
+		state.env.Table = tbl
+		state.env.QColumns = queryState.SelectedCols[state.env.Table]
+		return And(AggFunction, Str("as r1"))
+	}))
+
+	for i := 2; i < queryState.FieldNumHint; i++ {
+		fieldID := fmt.Sprintf("r%d", i)
+		fns = append(fns, Str(","))
+		fns = append(fns, NewFn(func(state *State) Fn {
+			state.env.Table = tbl
+			state.env.QColumns = queryState.SelectedCols[state.env.Table]
+			return And(Or(SelectFieldName, AggFunction), Str("as"), Str(fieldID))
+		}))
+	}
+	return And(fns...)
 })
 
 var SelectFields = NewFn(func(state *State) Fn {


### PR DESCRIPTION
Using `expression.BuildSimpleExpr` is insufficient to generate expression for `ast.AggregateFuncExpr`. As a workaround, here use `aggregation.NewAggFuncDesc` to get the corresponding `AggFuncDesc`.